### PR TITLE
Gui state persistence

### DIFF
--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMain.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMain.java
@@ -40,6 +40,7 @@ import moviescraper.doctord.controller.UpDirectoryAction;
 import moviescraper.doctord.controller.WriteFileDataAction;
 import moviescraper.doctord.dataitem.Actor;
 import moviescraper.doctord.dataitem.Title;
+import moviescraper.doctord.preferences.GuiSettings;
 import moviescraper.doctord.preferences.MoviescraperPreferences;
 
 import java.awt.Cursor;
@@ -97,6 +98,7 @@ public class GUIMain {
 	private File currentlySelectedDirectoryList;
 	private File defaultHomeDirectory;
 	private MoviescraperPreferences preferences;
+	private GuiSettings guiSettings;
 
 	//scraped movies
 	private Movie currentlySelectedMovieDMM;
@@ -184,7 +186,9 @@ public class GUIMain {
 	 */
 	private void initialize() {
 		
-		setPreferences(new MoviescraperPreferences());
+		preferences = new MoviescraperPreferences();
+		guiSettings = new GuiSettings();
+		
 		setCurrentlySelectedNfoFileList(new ArrayList<File>());
 		setCurrentlySelectedMovieFileList(new ArrayList<File>());
 		setCurrentlySelectedPosterFileList(new ArrayList<File>());
@@ -238,6 +242,10 @@ public class GUIMain {
 		fileListFileDetailSplitPane.setBorder(BorderFactory.createEmptyBorder());
 		fileListFileDetailSplitPane.setDividerSize(gap);
 		messageConsolePanel.setBorder(BorderFactory.createEmptyBorder(gap, 0, 0, 0));
+		
+		// restore gui state
+		buttonPanel.setVisible(guiSettings.getShowToolbar());
+		messageConsolePanel.setVisible(guiSettings.getShowOutputPanel());
 	}
 
 	/**
@@ -734,8 +742,8 @@ public class GUIMain {
 		return preferences;
 	}
 
-	public void setPreferences(MoviescraperPreferences preferences) {
-		this.preferences = preferences;
+	public GuiSettings getGuiSettings() {
+		return guiSettings;
 	}
 
 	public File getCurrentlySelectedDirectoryList() {
@@ -813,18 +821,22 @@ public class GUIMain {
 	
 	public void showMessageConsolePanel(){
 		messageConsolePanel.setVisible(true);
+		guiSettings.setShowOutputPanel(true);
 	}
 	
 	public void hideMessageConsolePanel(){
 		messageConsolePanel.setVisible(false);
+		guiSettings.setShowOutputPanel(false);
 	}
 	
 	public void showButtonPanel(){
 		buttonPanel.setVisible(true);
+		guiSettings.setShowToolbar(true);
 	}
 	
 	public void hideButtonPanel(){
 		buttonPanel.setVisible(false);
+		guiSettings.setShowToolbar(false);
 	}
 	
 	public Movie getCurrentlySelectedMovieR18() {

--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMain.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMain.java
@@ -141,6 +141,7 @@ public class GUIMain {
 	private static final int defaultMainFrameY = 768;
 
 	private final static boolean debugMessages = false;
+	private GUIMainButtonPanel buttonPanel;
 
 	/**
 	 * Launch the application.
@@ -227,8 +228,8 @@ public class GUIMain {
 		messageConsolePanel = new MessageConsolePanel();
 		frmMoviescraper.getContentPane().add(messageConsolePanel, BorderLayout.SOUTH);
 
-		// set up button panel
-		frmMoviescraper.getContentPane().add(new GUIMainButtonPanel(this), BorderLayout.NORTH);
+		buttonPanel = new GUIMainButtonPanel(this);
+		frmMoviescraper.getContentPane().add(buttonPanel, BorderLayout.NORTH);
 		
 		//add in the menu bar
 		frmMoviescraper.setJMenuBar(new GUIMainMenuBar(this));
@@ -818,6 +819,13 @@ public class GUIMain {
 		messageConsolePanel.setVisible(false);
 	}
 	
+	public void showButtonPanel(){
+		buttonPanel.setVisible(true);
+	}
+	
+	public void hideButtonPanel(){
+		buttonPanel.setVisible(false);
+	}
 	
 	public Movie getCurrentlySelectedMovieR18() {
 		return currentlySelectedMovieR18;

--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMain.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMain.java
@@ -208,7 +208,7 @@ public class GUIMain {
 		frmMoviescraper.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 
 		//create tree view icon provider
-		IconCache.setIconProvider(getPreferences().getUseContentBasedTypeIcons() ? IconCache.IconProviderType.CONTENT
+		IconCache.setIconProvider(getGuiSettings().getUseContentBasedTypeIcons() ? IconCache.IconProviderType.CONTENT
 						: IconCache.IconProviderType.SYSTEM);
 
 		//initialize the icons used in the program
@@ -256,7 +256,7 @@ public class GUIMain {
 	private void setUpFileListPanel() {
 		fileListPanel = new JPanel();
 
-		defaultHomeDirectory = getPreferences().getLastUsedDirectory();
+		defaultHomeDirectory = getGuiSettings().getLastUsedDirectory();
 		setCurrentlySelectedDirectoryList(defaultHomeDirectory);
 		
 		listModelFiles = new DefaultListModel<File>();
@@ -342,7 +342,7 @@ public class GUIMain {
 							}
 							finally
 							{
-								getPreferences().setLastUsedDirectory(getCurrentlySelectedDirectoryList());
+								getGuiSettings().setLastUsedDirectory(getCurrentlySelectedDirectoryList());
 								frmMoviescraper.setCursor(Cursor.getDefaultCursor());
 							}
 						}

--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainButtonPanel.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainButtonPanel.java
@@ -21,6 +21,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JToolBar;
+import javax.swing.MenuElement;
 import javax.swing.UIManager;
 
 import moviescraper.doctord.SiteParsingProfile.SiteParsingProfile;
@@ -146,6 +147,29 @@ public class GUIMainButtonPanel extends JPanel {
 		super.add(toolbar);
 	}
 	
+	private Action findScraperAction(MenuElement scrapeMenu, String scraperKey) {
+		
+		if (scrapeMenu instanceof JMenuItem){
+			JMenuItem menuItem = (JMenuItem)scrapeMenu;
+			Action action = menuItem.getAction();
+			if (action != null){
+				String key = (String)action.getValue(ScrapeMovieAction.SCRAPE_KEY);
+				if (key != null && key.equals(scraperKey)){
+					return action;
+				}
+			}
+		}
+		
+		for(MenuElement childMenu: scrapeMenu.getSubElements()){
+			Action childAction = findScraperAction(childMenu, scraperKey);
+			if (childAction != null){
+				return childAction;
+			}
+		}
+		
+		return null;
+	}
+	
 	private void initializeButtons()
 	{
 		initializeDirectoryButtons();
@@ -234,9 +258,10 @@ public class GUIMainButtonPanel extends JPanel {
 		ActionListener scrapeActionListener = new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				
 				Action action = ((JMenuItem)e.getSource()).getAction(); 
-				scrapeButton.setAction(action);;
+				scrapeButton.setAction(action);
+				String scraperKey = (String)action.getValue(ScrapeMovieAction.SCRAPE_KEY);
+				guiMain.getGuiSettings().setLastUsedScraper(scraperKey);
 			}
 		};
 		
@@ -272,11 +297,20 @@ public class GUIMainButtonPanel extends JPanel {
 			specificMenu.add(menuItem);
 		}
 		
-		scrapeButton.setAction(scrapeJavAutoAction);
+		String lastUsedScraper = guiMain.getGuiSettings().getLastUsedScraper();
+		Action scrapeAction = scrapeJavAutoAction;
+		
+		if (lastUsedScraper != null){
+			Action lastScrapeAction = findScraperAction(scrapeMenu, lastUsedScraper);
+			if (lastScrapeAction != null)
+				scrapeAction = lastScrapeAction;
+		}
+		
+		scrapeButton.setAction(scrapeAction);
 		
 		scrapeButtons.add(scrapeButton);
 		scrapeButtons.add(arrowButton);
 		
 		add(scrapeButtons);
-	}	
+	}
 }

--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainMenuBar.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainMenuBar.java
@@ -1,15 +1,11 @@
 package moviescraper.doctord.GUI;
 
-import java.awt.Desktop;
 import java.awt.Event;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.awt.event.KeyEvent;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
@@ -22,7 +18,6 @@ import moviescraper.doctord.SiteParsingProfile.SiteParsingProfileItem;
 import moviescraper.doctord.SiteParsingProfile.SpecificProfileFactory;
 import moviescraper.doctord.controller.BrowseDirectoryAction;
 import moviescraper.doctord.controller.BrowseUriAction;
-import moviescraper.doctord.controller.FileNameCleanupAction;
 import moviescraper.doctord.controller.MoveToNewFolderAction;
 import moviescraper.doctord.controller.OpenFileAction;
 import moviescraper.doctord.controller.RefreshDirectoryAction;
@@ -395,7 +390,22 @@ public class GUIMainMenuBar extends JMenuBar{
 			}
 		});
 		
-	
+		JCheckBoxMenuItem buttonPanelMenuItem = new JCheckBoxMenuItem("Show Tool Bar");
+		buttonPanelMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F11, 0));
+		buttonPanelMenuItem.setState(true);
+		buttonPanelMenuItem.addItemListener(new ItemListener() {
+			
+			@Override
+			public void itemStateChanged(ItemEvent e) {
+				if(e.getStateChange() == ItemEvent.SELECTED)
+					guiMain.showButtonPanel();
+				else if(e.getStateChange() == ItemEvent.DESELECTED)
+					guiMain.hideButtonPanel();	
+				
+			}
+		});
+		
+		viewMenu.add(buttonPanelMenuItem);
 		viewMenu.add(consoleInSeperateWindowMenuItem);
 		viewMenu.add(consolePanelMenuItem);
 	

--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainMenuBar.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainMenuBar.java
@@ -377,7 +377,7 @@ public class GUIMainMenuBar extends JMenuBar{
 		
 		JCheckBoxMenuItem consolePanelMenuItem = new JCheckBoxMenuItem("Show Output Panel");
 		consolePanelMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F12, 0));
-		consolePanelMenuItem.setState(false);
+		consolePanelMenuItem.setState(guiMain.getGuiSettings().getShowOutputPanel());
 		consolePanelMenuItem.addItemListener(new ItemListener() {
 
 			@Override
@@ -391,7 +391,7 @@ public class GUIMainMenuBar extends JMenuBar{
 		
 		JCheckBoxMenuItem buttonPanelMenuItem = new JCheckBoxMenuItem("Show Tool Bar");
 		buttonPanelMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F11, 0));
-		buttonPanelMenuItem.setState(true);
+		buttonPanelMenuItem.setState(guiMain.getGuiSettings().getShowToolbar());
 		buttonPanelMenuItem.addItemListener(new ItemListener() {
 			
 			@Override

--- a/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainMenuBar.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/GUI/GUIMainMenuBar.java
@@ -366,9 +366,7 @@ public class GUIMainMenuBar extends JMenuBar{
 		JMenu viewMenu = new JMenu("View");
 		viewMenu.setMnemonic(KeyEvent.VK_V);
 		
-				
-		
-		JMenuItem consoleInSeperateWindowMenuItem = new JMenuItem("View Console Output In Seperate Window");
+		JMenuItem consoleInSeperateWindowMenuItem = new JMenuItem("View Output In New Window");
 		consoleInSeperateWindowMenuItem.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent e) {
@@ -377,7 +375,8 @@ public class GUIMainMenuBar extends JMenuBar{
 		});
 		
 		
-		JCheckBoxMenuItem consolePanelMenuItem = new JCheckBoxMenuItem("Show Console Panel In Main Window");
+		JCheckBoxMenuItem consolePanelMenuItem = new JCheckBoxMenuItem("Show Output Panel");
+		consolePanelMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_F12, 0));
 		consolePanelMenuItem.setState(false);
 		consolePanelMenuItem.addItemListener(new ItemListener() {
 
@@ -406,9 +405,9 @@ public class GUIMainMenuBar extends JMenuBar{
 		});
 		
 		viewMenu.add(buttonPanelMenuItem);
-		viewMenu.add(consoleInSeperateWindowMenuItem);
 		viewMenu.add(consolePanelMenuItem);
-	
+		viewMenu.add(consoleInSeperateWindowMenuItem);
+		
 		add(viewMenu);
 	}
 	

--- a/JAVMovieScraper/src/moviescraper/doctord/controller/BrowseDirectoryAction.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/controller/BrowseDirectoryAction.java
@@ -25,8 +25,8 @@ public class BrowseDirectoryAction implements ActionListener {
 	public void actionPerformed(ActionEvent arg0) {
 		this.guiMain.setChooser(new JFileChooser());
 		//remember our last used directory and start the search there
-		if(this.guiMain.getPreferences().getLastUsedDirectory().exists())
-			this.guiMain.getChooser().setCurrentDirectory(this.guiMain.getPreferences().getLastUsedDirectory());
+		if(this.guiMain.getGuiSettings().getLastUsedDirectory().exists())
+			this.guiMain.getChooser().setCurrentDirectory(this.guiMain.getGuiSettings().getLastUsedDirectory());
 		this.guiMain.getChooser().setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
 		FileNameExtensionFilter filter = new FileNameExtensionFilter(
 				"Movies", "avi", "mp4", "wmv", "flv", "mov", "rm", "mkv");
@@ -44,7 +44,7 @@ public class BrowseDirectoryAction implements ActionListener {
 			}
 			finally
 			{
-				this.guiMain.getPreferences().setLastUsedDirectory(this.guiMain.getCurrentlySelectedDirectoryList());
+				this.guiMain.getGuiSettings().setLastUsedDirectory(this.guiMain.getCurrentlySelectedDirectoryList());
 				this.guiMain.getFrmMoviescraper().setCursor(Cursor.getDefaultCursor());
 			}
 

--- a/JAVMovieScraper/src/moviescraper/doctord/controller/ScrapeMovieAction.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/controller/ScrapeMovieAction.java
@@ -84,10 +84,12 @@ public class ScrapeMovieAction extends AbstractAction {
 	boolean scrapeCanceled;
 
 
+	public static final String SCRAPE_KEY = "SCRAPE_KEY";
 
 
 	public ScrapeMovieAction(GUIMain guiMain) {
 		this.guiMain = guiMain;
+		putValue(SCRAPE_KEY, getClass().getName());
 		putValue(NAME, "Scrape JAV");
 		putValue(SHORT_DESCRIPTION, "Scrape Selected Movie");
 		overrideURLDMM = "";

--- a/JAVMovieScraper/src/moviescraper/doctord/controller/ScrapeSpecificAction.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/controller/ScrapeSpecificAction.java
@@ -22,6 +22,8 @@ public class ScrapeSpecificAction extends AbstractAction {
 	public ScrapeSpecificAction(GUIMain main, SiteParsingProfile profile) {
 		this.main = main;
 		this.profile = profile;
+		
+		putValue(ScrapeMovieAction.SCRAPE_KEY, profile.getClass().getName());
 	}
 	
 	@Override

--- a/JAVMovieScraper/src/moviescraper/doctord/controller/UpDirectoryAction.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/controller/UpDirectoryAction.java
@@ -34,7 +34,7 @@ public class UpDirectoryAction implements ActionListener {
 		}
 		finally
 		{
-			this.guiMain.getPreferences().setLastUsedDirectory(this.guiMain.getCurrentlySelectedDirectoryList());
+			this.guiMain.getGuiSettings().setLastUsedDirectory(this.guiMain.getCurrentlySelectedDirectoryList());
 			this.guiMain.getFrmMoviescraper().setCursor(Cursor.getDefaultCursor());
 		}
 	}

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/GuiSettings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/GuiSettings.java
@@ -8,9 +8,10 @@ public class GuiSettings extends Settings {
 
 	enum Key implements Settings.Key {
 		lastUsedDirectory,
-		useContentBasedTypeIcons,		
-		showToolbar,
+		lastUsedScraper,
 		showOutputPanel,
+		showToolbar,
+		useContentBasedTypeIcons,		
 		;
 
 		@Override
@@ -72,5 +73,13 @@ public class GuiSettings extends Settings {
 	public void setUseContentBasedTypeIcons(boolean preferenceValue) {
 		setBooleanValue(Key.useContentBasedTypeIcons, preferenceValue);    
 	}
+
+	public String getLastUsedScraper(){
+		return getStringValue(Key.lastUsedScraper, null);
+	}
 	
+	public void setLastUsedScraper(String preferenceValue){
+		setStringValue(Key.lastUsedScraper, preferenceValue);
+	}
 }
+

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/GuiSettings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/GuiSettings.java
@@ -1,8 +1,14 @@
 package moviescraper.doctord.preferences;
 
+import java.io.File;
+
+import org.apache.commons.lang3.SystemUtils;
+
 public class GuiSettings extends Settings {
 
 	enum Key implements Settings.Key {
+		lastUsedDirectory,
+		useContentBasedTypeIcons,		
 		showToolbar,
 		showOutputPanel,
 		;
@@ -29,4 +35,42 @@ public class GuiSettings extends Settings {
 	public void setShowOutputPanel(boolean preferenceValue){
 		setBooleanValue(Key.showOutputPanel, preferenceValue);
 	}
+	
+
+	public File getLastUsedDirectory(){
+		String lastUsedDir =  getStringValue(Key.lastUsedDirectory, null);
+
+		if(lastUsedDir != null)
+		{
+			File lastUsedDirFile = new File(lastUsedDir);
+			if(lastUsedDirFile.exists())
+				return lastUsedDirFile;
+			else return new File(System.getProperty("user.home"));
+		}
+		else return new File(System.getProperty("user.home"));
+	}
+
+	public void setLastUsedDirectory(File lastUsedDirectoryFile){
+		setStringValue(Key.lastUsedDirectory, lastUsedDirectoryFile.getPath());
+	}
+	
+
+	public boolean getUseContentBasedTypeIcons() {
+	/*    
+     * Use icons in res/mime instead of system icons. 
+     * Needed for linux as system icons only show two types of icons otherwise (files and folders)
+     * There's no menu option for this preference, but you can manually modify the settings file yourself to enable it
+     * this option is also automatically enabled on linux
+     */
+
+		// if we're on linux we want the content based icons as default        
+		boolean defaultValue = SystemUtils.IS_OS_LINUX;
+
+		return getBooleanValue(Key.useContentBasedTypeIcons, defaultValue);
+	}
+
+	public void setUseContentBasedTypeIcons(boolean preferenceValue) {
+		setBooleanValue(Key.useContentBasedTypeIcons, preferenceValue);    
+	}
+	
 }

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/GuiSettings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/GuiSettings.java
@@ -1,0 +1,32 @@
+package moviescraper.doctord.preferences;
+
+public class GuiSettings extends Settings {
+
+	enum Key implements Settings.Key {
+		showToolbar,
+		showOutputPanel,
+		;
+
+		@Override
+		public String getKey() {
+			// prefix setting key to avoid clashing
+			return "Gui:" + toString();
+		}	
+	}
+	
+	public boolean getShowToolbar(){
+		return getBooleanValue(Key.showToolbar, true);
+	}
+	
+	public void setShowToolbar(boolean preferenceValue){
+		setBooleanValue(Key.showToolbar, preferenceValue);
+	}
+	
+	public boolean getShowOutputPanel(){
+		return getBooleanValue(Key.showOutputPanel, false);
+	}
+	
+	public void setShowOutputPanel(boolean preferenceValue){
+		setBooleanValue(Key.showOutputPanel, preferenceValue);
+	}
+}

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
@@ -22,7 +22,7 @@ public class MoviescraperPreferences extends Settings {
 
 		@Override
 		public String getKey() {
-			return toString();
+			return "Preferences:" + toString();
 		}
 	}
 	

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
@@ -1,45 +1,36 @@
 package moviescraper.doctord.preferences;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.util.InvalidPropertiesFormatException;
-import java.util.Properties;
 
 import org.apache.commons.lang3.SystemUtils;
 
 public class MoviescraperPreferences extends Settings {
 
-	//for the property names, it's important (because of reflection) that the values be kept the same as the variable names
-	//this lets me be lazy and reuse code for each property setter/getter using a common method :)
-	//so don't go renaming these variables without being aware of the consequences!
-	protected static final String lastUsedDirectory = "lastUsedDirectory";
-	protected static final String writeFanartAndPosters = "writeFanartAndPosters";
-	protected static final String overwriteFanartAndPosters = "overwriteFanartAndPosters";
-	protected static final String downloadActorImagesToActorFolder = "downloadActorImagesToActorFolder";
-	protected static final String extraFanartScrapingEnabled = "extraFanartScrapingEnabled";
-	protected static final String createFolderJpg = "createFolderJpg";
-	protected static final String noMovieNameInImageFiles = "noMovieNameInImageFiles";
-	protected static final String writeTrailerToFile = "writeTrailerToFile";
-	protected static final String nfoNamedMovieDotNfo = "nfoNamedMovieDotNfo";
-	protected static final String useIAFDForActors = "useIAFDForActors";
-	protected static final String sanitizerForFilename = "sanitizerForFilename";
-	protected static final String renamerString = "renamerString";
-	protected static final String renameMovieFile = "renameMovieFile";
-	protected static final String scrapeInJapanese = "scrapeInJapanese";
-	protected static final String promptForUserProvidedURLWhenScraping = "promptForUserProvidedURLWhenScraping";
-	
-	/*
-	 * useContentBasedTypeIcons:
-	 * Use icons in res/mime instead of system icons. 
-	 * Needed for linux as system icons only show two types of icons otherwise (files and folders)
-	 * There's no menu option for this preference, but you can manually modify the settings file yourself to enable it
-	 * this option is also automatically enabled on linux
-	 */
-	
-	protected static final String useContentBasedTypeIcons = "useContentBasedTypeIcons";
+	enum Key implements Settings.Key {
+		lastUsedDirectory,
+		writeFanartAndPosters,
+		overwriteFanartAndPosters,
+		downloadActorImagesToActorFolder,
+		extraFanartScrapingEnabled,
+		createFolderJpg,
+		noMovieNameInImageFiles,
+		writeTrailerToFile,
+		nfoNamedMovieDotNfo,
+		useIAFDForActors,
+		sanitizerForFilename, 
+		renamerString,
+		renameMovieFile,
+		scrapeInJapanese,
+		promptForUserProvidedURLWhenScraping,
+		useContentBasedTypeIcons,
+		;
 
+		@Override
+		public String getKey() {
+			return toString();
+		}
+	}
+	
 	public MoviescraperPreferences(){
 		super();
 		
@@ -49,7 +40,8 @@ public class MoviescraperPreferences extends Settings {
 	}
 
 	public File getLastUsedDirectory(){
-		String lastUsedDir = getStringValue(lastUsedDirectory, null);
+		String lastUsedDir =  getStringValue(Key.lastUsedDirectory, null);
+
 		if(lastUsedDir != null)
 		{
 			File lastUsedDirFile = new File(lastUsedDir);
@@ -61,145 +53,143 @@ public class MoviescraperPreferences extends Settings {
 	}
 
 	public void setLastUsedDirectory(File lastUsedDirectoryFile){
-		setStringValue(lastUsedDirectory, lastUsedDirectoryFile.getPath());
+		setStringValue(Key.lastUsedDirectory, lastUsedDirectoryFile.getPath());
 	}
 
 	public void setOverWriteFanartAndPostersPreference(boolean preferenceValue){
-		setBooleanValue(overwriteFanartAndPosters, preferenceValue);
+		setBooleanValue(Key.overwriteFanartAndPosters, preferenceValue);
 	}
 
 	public boolean getOverWriteFanartAndPostersPreference()
 	{
-		return getBooleanValue(overwriteFanartAndPosters, true);
+		return getBooleanValue(Key.overwriteFanartAndPosters, true);
 	}
 
 	public void setWriteFanartAndPostersPreference(boolean preferenceValue){
-		setBooleanValue(writeFanartAndPosters, preferenceValue);
+		setBooleanValue(Key.writeFanartAndPosters, preferenceValue);
 	}
 
 
 
 	public void setDownloadActorImagesToActorFolderPreference(boolean preferenceValue)
 	{
-		setBooleanValue(downloadActorImagesToActorFolder, preferenceValue);
+		setBooleanValue(Key.downloadActorImagesToActorFolder, preferenceValue);
 	}
 
 	public boolean getDownloadActorImagesToActorFolderPreference()
 	{
-		return getBooleanValue(downloadActorImagesToActorFolder, true);
+		return getBooleanValue(Key.downloadActorImagesToActorFolder, true);
 	}
 
 	public boolean getWriteFanartAndPostersPreference() {
-		/*String writeFanartAndPostersPref = getStringValue(writeFanartAndPosters);
-		if(writeFanartAndPostersPref != null)
-		{
-		if(writeFanartAndPostersPref.equals("true"))
-			return true;
-		else return false;
-		}
-		else return true; //default value if no preference has been set yet*/
-		return getBooleanValue(writeFanartAndPosters, true);
+		return getBooleanValue(Key.writeFanartAndPosters, true);
 	}
 
 	public boolean getExtraFanartScrapingEnabledPreference() {
-		return getBooleanValue(extraFanartScrapingEnabled, false);
+		return getBooleanValue(Key.extraFanartScrapingEnabled, false);
 	}
 
 	public void setExtraFanartScrapingEnabledPreference(boolean preferenceValue){
-		setBooleanValue(extraFanartScrapingEnabled, preferenceValue);
+		setBooleanValue(Key.extraFanartScrapingEnabled, preferenceValue);
 	}
 
 	public void setCreateFolderJpgEnabledPreference(boolean preferenceValue) {
-		setBooleanValue(createFolderJpg, preferenceValue);
+		setBooleanValue(Key.createFolderJpg, preferenceValue);
 
 	}
 
 	public boolean getCreateFolderJpgEnabledPreference() {
-		return getBooleanValue(createFolderJpg, false);
+		return getBooleanValue(Key.createFolderJpg, false);
 	}
 
 	public boolean getNoMovieNameInImageFiles(){
-		return getBooleanValue(noMovieNameInImageFiles, false);
+		return getBooleanValue(Key.noMovieNameInImageFiles, false);
 	}
 
 	public void setNoMovieNameInImageFiles(boolean preferenceValue){
-		setBooleanValue(noMovieNameInImageFiles, preferenceValue);
+		setBooleanValue(Key.noMovieNameInImageFiles, preferenceValue);
 	}
 
 	public boolean getWriteTrailerToFile(){
-		return getBooleanValue(writeTrailerToFile, false);
+		return getBooleanValue(Key.writeTrailerToFile, false);
 	}
 
 	public void setWriteTrailerToFile(boolean preferenceValue){
-		setBooleanValue(writeTrailerToFile, preferenceValue);
+		setBooleanValue(Key.writeTrailerToFile, preferenceValue);
 	}
 
 	public boolean getNfoNamedMovieDotNfo(){
-		return getBooleanValue(nfoNamedMovieDotNfo, false);
+		return getBooleanValue(Key.nfoNamedMovieDotNfo, false);
 	}
 
 	public void setNfoNamedMovieDotNfo(boolean preferenceValue){
-		setBooleanValue(nfoNamedMovieDotNfo, preferenceValue);
+		setBooleanValue(Key.nfoNamedMovieDotNfo, preferenceValue);
 	}
 
 	public boolean getUseIAFDForActors() {
-		return getBooleanValue(useIAFDForActors, false);
+		return getBooleanValue(Key.useIAFDForActors, false);
 	}
 
 	public void setUseIAFDForActors(boolean preferenceValue) {
-		setBooleanValue(useIAFDForActors, preferenceValue);
+		setBooleanValue(Key.useIAFDForActors, preferenceValue);
 	}
 
 	public String getSanitizerForFilename() {
-		return getStringValue(sanitizerForFilename, "[\\\\/:*?\"<>|\\r\\n]|[ ]+$|(?<=[^.])[.]+$|(?<=.{250})(.+)(?=[.]\\p{Alnum}{3}$)");
+		return getStringValue(Key.sanitizerForFilename, "[\\\\/:*?\"<>|\\r\\n]|[ ]+$|(?<=[^.])[.]+$|(?<=.{250})(.+)(?=[.]\\p{Alnum}{3}$)");
 	}
 
 	public void setSanitizerForFilename(String preferenceValue) {
-		setStringValue(sanitizerForFilename, preferenceValue);
+		setStringValue(Key.sanitizerForFilename, preferenceValue);
 	}
 
 	public String getRenamerString() {
-		return getStringValue(renamerString, "<TITLE> [<ACTORS>] (<YEAR>) [<ID>]");
+		return getStringValue(Key.renamerString, "<TITLE> [<ACTORS>] (<YEAR>) [<ID>]");
 	}
 
 	public void setRenamerString(String preferenceValue) {
-		setStringValue(renamerString, preferenceValue);
+		setStringValue(Key.renamerString, preferenceValue);
 	}
 
 	public boolean getRenameMovieFile() {
-		return getBooleanValue(renameMovieFile, false);
+		return getBooleanValue(Key.renameMovieFile, false);
 	}
 
 	public void setRenameMovieFile(boolean preferenceValue) {
-		setBooleanValue(renameMovieFile, preferenceValue);
+		setBooleanValue(Key.renameMovieFile, preferenceValue);
 	}
 
 	public boolean getScrapeInJapanese(){
-		return getBooleanValue(scrapeInJapanese, false);
+		return getBooleanValue(Key.scrapeInJapanese, false);
 	}
 
 	public void setScrapeInJapanese(boolean preferenceValue){
-		setBooleanValue(scrapeInJapanese, preferenceValue);
+		setBooleanValue(Key.scrapeInJapanese, preferenceValue);
 	}
 
 	public boolean getUseContentBasedTypeIcons() {
+	/*    
+     * Use icons in res/mime instead of system icons. 
+     * Needed for linux as system icons only show two types of icons otherwise (files and folders)
+     * There's no menu option for this preference, but you can manually modify the settings file yourself to enable it
+     * this option is also automatically enabled on linux
+     */
 
 		// if we're on linux we want the content based icons as default        
 		boolean defaultValue = SystemUtils.IS_OS_LINUX;
 
-		return getBooleanValue(useContentBasedTypeIcons, defaultValue);
+		return getBooleanValue(Key.useContentBasedTypeIcons, defaultValue);
 	}
 
 	public void setUseContentBasedTypeIcons(boolean preferenceValue) {
-		setBooleanValue(useContentBasedTypeIcons, preferenceValue);    
+		setBooleanValue(Key.useContentBasedTypeIcons, preferenceValue);    
 	}
 	
 	public boolean getPromptForUserProvidedURLWhenScraping(){
-		return getBooleanValue(promptForUserProvidedURLWhenScraping, false);
+		return getBooleanValue(Key.promptForUserProvidedURLWhenScraping, false);
 	}
 
 	public void setPromptForUserProvidedURLWhenScraping(boolean preferenceValue){
-		setBooleanValue(promptForUserProvidedURLWhenScraping, preferenceValue);
+		setBooleanValue(Key.promptForUserProvidedURLWhenScraping, preferenceValue);
 	}
 
 

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
@@ -1,13 +1,9 @@
 package moviescraper.doctord.preferences;
 
-import java.io.File;
-
-import org.apache.commons.lang3.SystemUtils;
 
 public class MoviescraperPreferences extends Settings {
 
 	enum Key implements Settings.Key {
-		lastUsedDirectory,
 		writeFanartAndPosters,
 		overwriteFanartAndPosters,
 		downloadActorImagesToActorFolder,
@@ -22,7 +18,6 @@ public class MoviescraperPreferences extends Settings {
 		renameMovieFile,
 		scrapeInJapanese,
 		promptForUserProvidedURLWhenScraping,
-		useContentBasedTypeIcons,
 		;
 
 		@Override
@@ -39,22 +34,6 @@ public class MoviescraperPreferences extends Settings {
 		setRenamerString(getRenamerString());
 	}
 
-	public File getLastUsedDirectory(){
-		String lastUsedDir =  getStringValue(Key.lastUsedDirectory, null);
-
-		if(lastUsedDir != null)
-		{
-			File lastUsedDirFile = new File(lastUsedDir);
-			if(lastUsedDirFile.exists())
-				return lastUsedDirFile;
-			else return new File(System.getProperty("user.home"));
-		}
-		else return new File(System.getProperty("user.home"));
-	}
-
-	public void setLastUsedDirectory(File lastUsedDirectoryFile){
-		setStringValue(Key.lastUsedDirectory, lastUsedDirectoryFile.getPath());
-	}
 
 	public void setOverWriteFanartAndPostersPreference(boolean preferenceValue){
 		setBooleanValue(Key.overwriteFanartAndPosters, preferenceValue);
@@ -164,24 +143,6 @@ public class MoviescraperPreferences extends Settings {
 
 	public void setScrapeInJapanese(boolean preferenceValue){
 		setBooleanValue(Key.scrapeInJapanese, preferenceValue);
-	}
-
-	public boolean getUseContentBasedTypeIcons() {
-	/*    
-     * Use icons in res/mime instead of system icons. 
-     * Needed for linux as system icons only show two types of icons otherwise (files and folders)
-     * There's no menu option for this preference, but you can manually modify the settings file yourself to enable it
-     * this option is also automatically enabled on linux
-     */
-
-		// if we're on linux we want the content based icons as default        
-		boolean defaultValue = SystemUtils.IS_OS_LINUX;
-
-		return getBooleanValue(Key.useContentBasedTypeIcons, defaultValue);
-	}
-
-	public void setUseContentBasedTypeIcons(boolean preferenceValue) {
-		setBooleanValue(Key.useContentBasedTypeIcons, preferenceValue);    
 	}
 	
 	public boolean getPromptForUserProvidedURLWhenScraping(){

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
@@ -3,36 +3,32 @@ package moviescraper.doctord.preferences;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.InvalidPropertiesFormatException;
 import java.util.Properties;
 
 import org.apache.commons.lang3.SystemUtils;
 
-public class MoviescraperPreferences {
+public class MoviescraperPreferences extends Settings {
 
-	Properties programPreferences;
-	private static final String fileNameOfPreferences = "settings.xml";
 	//for the property names, it's important (because of reflection) that the values be kept the same as the variable names
 	//this lets me be lazy and reuse code for each property setter/getter using a common method :)
 	//so don't go renaming these variables without being aware of the consequences!
-	private static final String lastUsedDirectory = "lastUsedDirectory";
-	private static final String writeFanartAndPosters = "writeFanartAndPosters";
-	private static final String overwriteFanartAndPosters = "overwriteFanartAndPosters";
-	private static final String downloadActorImagesToActorFolder = "downloadActorImagesToActorFolder";
-	private static final String extraFanartScrapingEnabled = "extraFanartScrapingEnabled";
-	private static final String createFolderJpg = "createFolderJpg";
-	private static final String noMovieNameInImageFiles = "noMovieNameInImageFiles";
-	private static final String writeTrailerToFile = "writeTrailerToFile";
-	private static final String nfoNamedMovieDotNfo = "nfoNamedMovieDotNfo";
-	private static final String useIAFDForActors = "useIAFDForActors";
-	private static final String sanitizerForFilename = "sanitizerForFilename";
-	private static final String renamerString = "renamerString";
-	private static final String renameMovieFile = "renameMovieFile";
-	private static final String scrapeInJapanese = "scrapeInJapanese";
-	private static final String promptForUserProvidedURLWhenScraping = "promptForUserProvidedURLWhenScraping";
+	protected static final String lastUsedDirectory = "lastUsedDirectory";
+	protected static final String writeFanartAndPosters = "writeFanartAndPosters";
+	protected static final String overwriteFanartAndPosters = "overwriteFanartAndPosters";
+	protected static final String downloadActorImagesToActorFolder = "downloadActorImagesToActorFolder";
+	protected static final String extraFanartScrapingEnabled = "extraFanartScrapingEnabled";
+	protected static final String createFolderJpg = "createFolderJpg";
+	protected static final String noMovieNameInImageFiles = "noMovieNameInImageFiles";
+	protected static final String writeTrailerToFile = "writeTrailerToFile";
+	protected static final String nfoNamedMovieDotNfo = "nfoNamedMovieDotNfo";
+	protected static final String useIAFDForActors = "useIAFDForActors";
+	protected static final String sanitizerForFilename = "sanitizerForFilename";
+	protected static final String renamerString = "renamerString";
+	protected static final String renameMovieFile = "renameMovieFile";
+	protected static final String scrapeInJapanese = "scrapeInJapanese";
+	protected static final String promptForUserProvidedURLWhenScraping = "promptForUserProvidedURLWhenScraping";
 	
 	/*
 	 * useContentBasedTypeIcons:
@@ -42,40 +38,14 @@ public class MoviescraperPreferences {
 	 * this option is also automatically enabled on linux
 	 */
 	
-	private static final String useContentBasedTypeIcons = "useContentBasedTypeIcons";
+	protected static final String useContentBasedTypeIcons = "useContentBasedTypeIcons";
 
-	public MoviescraperPreferences()
-	{
-		programPreferences = new Properties();
-		try {
-			programPreferences.loadFromXML(new FileInputStream(fileNameOfPreferences));
-			//initialize default values that must exist in the settings file
-			setSanitizerForFilename(getSanitizerForFilename());
-			setRenamerString(getRenamerString());
-		} catch (InvalidPropertiesFormatException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (FileNotFoundException e) {
-			savePreferences(); //file doesn't exist. this will create the file
-			//initialize default values that must exist in the settings file
-			setSanitizerForFilename(getSanitizerForFilename());
-			setRenamerString(getRenamerString());
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-
-	public void savePreferences(){
-		try {
-			programPreferences.storeToXML(new FileOutputStream(fileNameOfPreferences), "");
-		} catch (FileNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		} catch (IOException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+	public MoviescraperPreferences(){
+		super();
+		
+		//initialize default values that must exist in the settings file
+		setSanitizerForFilename(getSanitizerForFilename());
+		setRenamerString(getRenamerString());
 	}
 
 	public File getLastUsedDirectory(){
@@ -108,48 +78,6 @@ public class MoviescraperPreferences {
 		setBooleanValue(writeFanartAndPosters, preferenceValue);
 	}
 
-
-
-	private void setBooleanValue(String preferenceName, boolean preferenceValue) {
-		Field fieldToUse;
-		try {
-			fieldToUse = this.getClass().getDeclaredField(preferenceName);
-			if(preferenceValue)
-				programPreferences.setProperty((String)fieldToUse.get(new String()), "true");
-			else
-				programPreferences.setProperty((String)fieldToUse.get(new String()), "false");
-			savePreferences();
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-
-	}
-	/**
-	 * 
-	 * @param preferenceName the preference field to set - must be the exact same as the field's local variable name in {@link MoviescraperPreferences}
-	 * @param defaultValue the value to return if the preference has not been set
-	 * @return
-	 */
-	private boolean getBooleanValue(String preferenceName, boolean defaultValue)
-	{
-		Field fieldToUse;
-		try {
-			fieldToUse = this.getClass().getDeclaredField(preferenceName);
-			String fieldValue = (String)fieldToUse.get(new String());
-			String preferenceValue = programPreferences.getProperty(fieldValue);
-			if(preferenceValue == null)
-				return defaultValue;
-			if(preferenceValue.equals("true"))
-				return true;
-			else if(preferenceValue.equals("false"))
-				return false;
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		return defaultValue;
-	}
 
 
 	public void setDownloadActorImagesToActorFolderPreference(boolean preferenceValue)
@@ -276,9 +204,6 @@ public class MoviescraperPreferences {
 	public void setPromptForUserProvidedURLWhenScraping(boolean preferenceValue){
 		setBooleanValue(promptForUserProvidedURLWhenScraping, preferenceValue);
 	}
-	
-	public String toString(){
-		return programPreferences.toString();
-	}
+
 
 }

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
@@ -62,7 +62,6 @@ public class MoviescraperPreferences extends Settings {
 
 	public void setLastUsedDirectory(File lastUsedDirectoryFile){
 		setStringValue(lastUsedDirectory, lastUsedDirectoryFile.getPath());
-		savePreferences();
 	}
 
 	public void setOverWriteFanartAndPostersPreference(boolean preferenceValue){
@@ -165,7 +164,6 @@ public class MoviescraperPreferences extends Settings {
 
 	public void setRenamerString(String preferenceValue) {
 		setStringValue(renamerString, preferenceValue);
-		savePreferences();
 	}
 
 	public boolean getRenameMovieFile() {
@@ -174,7 +172,6 @@ public class MoviescraperPreferences extends Settings {
 
 	public void setRenameMovieFile(boolean preferenceValue) {
 		setBooleanValue(renameMovieFile, preferenceValue);
-		savePreferences();
 	}
 
 	public boolean getScrapeInJapanese(){

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/MoviescraperPreferences.java
@@ -49,7 +49,7 @@ public class MoviescraperPreferences extends Settings {
 	}
 
 	public File getLastUsedDirectory(){
-		String lastUsedDir = programPreferences.getProperty(lastUsedDirectory);
+		String lastUsedDir = getStringValue(lastUsedDirectory, null);
 		if(lastUsedDir != null)
 		{
 			File lastUsedDirFile = new File(lastUsedDir);
@@ -61,7 +61,7 @@ public class MoviescraperPreferences extends Settings {
 	}
 
 	public void setLastUsedDirectory(File lastUsedDirectoryFile){
-		programPreferences.setProperty(lastUsedDirectory, lastUsedDirectoryFile.getPath());
+		setStringValue(lastUsedDirectory, lastUsedDirectoryFile.getPath());
 		savePreferences();
 	}
 
@@ -91,7 +91,7 @@ public class MoviescraperPreferences extends Settings {
 	}
 
 	public boolean getWriteFanartAndPostersPreference() {
-		/*String writeFanartAndPostersPref = programPreferences.getProperty(writeFanartAndPosters);
+		/*String writeFanartAndPostersPref = getStringValue(writeFanartAndPosters);
 		if(writeFanartAndPostersPref != null)
 		{
 		if(writeFanartAndPostersPref.equals("true"))
@@ -152,19 +152,19 @@ public class MoviescraperPreferences extends Settings {
 	}
 
 	public String getSanitizerForFilename() {
-		return programPreferences.getProperty(sanitizerForFilename, "[\\\\/:*?\"<>|\\r\\n]|[ ]+$|(?<=[^.])[.]+$|(?<=.{250})(.+)(?=[.]\\p{Alnum}{3}$)");
+		return getStringValue(sanitizerForFilename, "[\\\\/:*?\"<>|\\r\\n]|[ ]+$|(?<=[^.])[.]+$|(?<=.{250})(.+)(?=[.]\\p{Alnum}{3}$)");
 	}
 
 	public void setSanitizerForFilename(String preferenceValue) {
-		programPreferences.setProperty(sanitizerForFilename, preferenceValue);
+		setStringValue(sanitizerForFilename, preferenceValue);
 	}
 
 	public String getRenamerString() {
-		return programPreferences.getProperty(renamerString, "<TITLE> [<ACTORS>] (<YEAR>) [<ID>]");
+		return getStringValue(renamerString, "<TITLE> [<ACTORS>] (<YEAR>) [<ID>]");
 	}
 
 	public void setRenamerString(String preferenceValue) {
-		programPreferences.setProperty(renamerString, preferenceValue);
+		setStringValue(renamerString, preferenceValue);
 		savePreferences();
 	}
 

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
@@ -10,8 +10,8 @@ import java.util.Properties;
 
 public class Settings {
 
-	protected static Properties programPreferences;
-	protected static final String fileNameOfPreferences = "settings.xml";
+	private static Properties programPreferences;
+	private static final String fileNameOfPreferences = "settings.xml";
 	
 	/*initialization block*/{
 		programPreferences = new Properties();
@@ -85,9 +85,44 @@ public class Settings {
 		return defaultValue;
 	}
 	
+
+	protected void setStringValue(String preferenceName, String preferenceValue) {
+		Field fieldToUse;
+		try {
+			fieldToUse = this.getClass().getDeclaredField(preferenceName);
+			programPreferences.setProperty((String)fieldToUse.get(new String()), preferenceValue);
+			savePreferences();
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	
+	}
+
+	/**
+	 * 
+	 * @param preferenceName the preference field to set - must be the exact same as the field's local variable name in {@link MoviescraperPreferences}
+	 * @param defaultValue the value to return if the preference has not been set
+	 * @return
+	 */
+	protected String getStringValue(String preferenceName, String defaultValue) {
+		Field fieldToUse;
+		try {
+			fieldToUse = this.getClass().getDeclaredField(preferenceName);
+			String fieldValue = (String)fieldToUse.get(new String());
+			String preferenceValue = programPreferences.getProperty(fieldValue);
+			if(preferenceValue != null)
+				return preferenceValue;
+			
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return defaultValue;
+	}
+	
 	
 	public String toString(){
 		return programPreferences.toString();
 	}
-
 }

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
@@ -52,7 +52,7 @@ public class Settings {
 		if(preferenceValue)
 			programPreferences.setProperty(key, "true");
 		else
-			programPreferences.setProperty(preferenceName.toString(), "false");
+			programPreferences.setProperty(key, "false");
 		
 		savePreferences();
 	}

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
@@ -4,7 +4,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.InvalidPropertiesFormatException;
 import java.util.Properties;
 
@@ -12,7 +11,11 @@ public class Settings {
 
 	private static Properties programPreferences;
 	private static final String fileNameOfPreferences = "settings.xml";
-	
+
+	protected interface Key {
+		String getKey(); 
+	}
+
 	/*initialization block*/{
 		programPreferences = new Properties();
 		try {
@@ -44,84 +47,50 @@ public class Settings {
 		}
 	}
 
-	protected void setBooleanValue(String preferenceName, boolean preferenceValue) {
-		Field fieldToUse;
-		try {
-			fieldToUse = this.getClass().getDeclaredField(preferenceName);
-			if(preferenceValue)
-				programPreferences.setProperty((String)fieldToUse.get(new String()), "true");
-			else
-				programPreferences.setProperty((String)fieldToUse.get(new String()), "false");
-			savePreferences();
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	
+	protected <K extends Key> void setBooleanValue(K preferenceName, boolean preferenceValue) {
+		String key = preferenceName.getKey();
+		if(preferenceValue)
+			programPreferences.setProperty(key, "true");
+		else
+			programPreferences.setProperty(preferenceName.toString(), "false");
+		
+		savePreferences();
 	}
 
 	/**
 	 * 
-	 * @param preferenceName the preference field to set - must be the exact same as the field's local variable name in {@link MoviescraperPreferences}
+	 * @param preferenceName the preference field to set
 	 * @param defaultValue the value to return if the preference has not been set
 	 * @return
 	 */
-	protected boolean getBooleanValue(String preferenceName, boolean defaultValue) {
-		Field fieldToUse;
-		try {
-			fieldToUse = this.getClass().getDeclaredField(preferenceName);
-			String fieldValue = (String)fieldToUse.get(new String());
-			String preferenceValue = programPreferences.getProperty(fieldValue);
-			if(preferenceValue == null)
-				return defaultValue;
-			if(preferenceValue.equals("true"))
-				return true;
-			else if(preferenceValue.equals("false"))
-				return false;
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+	protected <K extends Key> boolean getBooleanValue(K preferenceName, boolean defaultValue) {
+		String fieldValue = preferenceName.getKey();
+		String preferenceValue = programPreferences.getProperty(fieldValue);
+		if(preferenceValue == null)
+			return defaultValue;
+		if(preferenceValue.equals("true"))
+			return true;
+		else if(preferenceValue.equals("false"))
+			return false;
+		
 		return defaultValue;
 	}
 	
-
-	protected void setStringValue(String preferenceName, String preferenceValue) {
-		Field fieldToUse;
-		try {
-			fieldToUse = this.getClass().getDeclaredField(preferenceName);
-			programPreferences.setProperty((String)fieldToUse.get(new String()), preferenceValue);
-			savePreferences();
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	
+	protected <K extends Key>  void setStringValue(K preferenceName, String preferenceValue) {
+		programPreferences.setProperty(preferenceName.getKey(), preferenceValue);
+		savePreferences();
 	}
 
-	/**
-	 * 
-	 * @param preferenceName the preference field to set - must be the exact same as the field's local variable name in {@link MoviescraperPreferences}
-	 * @param defaultValue the value to return if the preference has not been set
-	 * @return
-	 */
-	protected String getStringValue(String preferenceName, String defaultValue) {
-		Field fieldToUse;
-		try {
-			fieldToUse = this.getClass().getDeclaredField(preferenceName);
-			String fieldValue = (String)fieldToUse.get(new String());
-			String preferenceValue = programPreferences.getProperty(fieldValue);
-			if(preferenceValue != null)
-				return preferenceValue;
-			
-		} catch (Exception e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
+	protected <K extends Key> String getStringValue(K preferenceName, String defaultValue) {
+		String fieldValue = preferenceName.getKey();
+		String preferenceValue = programPreferences.getProperty(fieldValue);
+		if(preferenceValue != null)
+			return preferenceValue;
+		
 		return defaultValue;
 	}
 	
-	
+		
 	public String toString(){
 		return programPreferences.toString();
 	}

--- a/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/preferences/Settings.java
@@ -1,0 +1,93 @@
+package moviescraper.doctord.preferences;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.InvalidPropertiesFormatException;
+import java.util.Properties;
+
+public class Settings {
+
+	protected static Properties programPreferences;
+	protected static final String fileNameOfPreferences = "settings.xml";
+	
+	/*initialization block*/{
+		programPreferences = new Properties();
+		try {
+			programPreferences.loadFromXML(new FileInputStream(fileNameOfPreferences));
+		} catch (InvalidPropertiesFormatException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (FileNotFoundException e) {
+			savePreferences(); //file doesn't exist. this will create the file
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	public Settings() {
+		super();
+	}
+
+	public void savePreferences() {
+		try {
+			programPreferences.storeToXML(new FileOutputStream(fileNameOfPreferences), "");
+		} catch (FileNotFoundException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		} catch (IOException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	protected void setBooleanValue(String preferenceName, boolean preferenceValue) {
+		Field fieldToUse;
+		try {
+			fieldToUse = this.getClass().getDeclaredField(preferenceName);
+			if(preferenceValue)
+				programPreferences.setProperty((String)fieldToUse.get(new String()), "true");
+			else
+				programPreferences.setProperty((String)fieldToUse.get(new String()), "false");
+			savePreferences();
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	
+	}
+
+	/**
+	 * 
+	 * @param preferenceName the preference field to set - must be the exact same as the field's local variable name in {@link MoviescraperPreferences}
+	 * @param defaultValue the value to return if the preference has not been set
+	 * @return
+	 */
+	protected boolean getBooleanValue(String preferenceName, boolean defaultValue) {
+		Field fieldToUse;
+		try {
+			fieldToUse = this.getClass().getDeclaredField(preferenceName);
+			String fieldValue = (String)fieldToUse.get(new String());
+			String preferenceValue = programPreferences.getProperty(fieldValue);
+			if(preferenceValue == null)
+				return defaultValue;
+			if(preferenceValue.equals("true"))
+				return true;
+			else if(preferenceValue.equals("false"))
+				return false;
+		} catch (Exception e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		return defaultValue;
+	}
+	
+	
+	public String toString(){
+		return programPreferences.toString();
+	}
+
+}


### PR DESCRIPTION
This is the gui state persistence code. Toolbar and console panel visibility and  last used scrape action is saved and restored on program launch. 

I refactored the preferences class to split gui and scraping settings in two different classes, with the same base class sharing the settings file handling. String constant keys are now enums, easier to work with and still strongly typed.

File setting keys have now a prefix so old settings won't take effect. You can edit the settings.xml file and add the proper prefix by hand or delete and let the program recreate it.