### PR TITLE
R18 changes

### DIFF
--- a/JAVMovieScraper/src/moviescraper/doctord/SiteParsingProfile/specific/DmmParsingProfile.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/SiteParsingProfile/specific/DmmParsingProfile.java
@@ -443,9 +443,9 @@ public class DmmParsingProfile extends SiteParsingProfile implements SpecificPro
 		int firstNumberIndex = StringUtils.indexOfAny(idElementText, "0123456789");
 		idElementText = idElementText.substring(0,firstNumberIndex) + "-" + idElementText.substring(firstNumberIndex);
 		
-		//remove extra zeros in case we get a 5 digit numerical part 
+		//remove extra zeros in case we get a 5 or 6 digit numerical part 
 		//(For example ABC-00123 will become ABC-123)
-		Pattern patternID = Pattern.compile("([0-9]*\\D+)(\\d{5})");
+		Pattern patternID = Pattern.compile("([0-9]*\\D+)(\\d{5,6})");
 		Matcher matcher = patternID.matcher(idElementText);
 		String groupOne = "";
 		String groupTwo = "";


### PR DESCRIPTION
Hi there. Got some time and decided to tinker with the R18 scraper.

I've been doing lots of searches on the website form and finally figured out how to get some decent results without doing several searches or going through google. The trick here is to left pad the tag number with 5 zeros, most titles will get a single, right result.

Some titles with five digit id numbers may need an extra pad, I've take this into account for one series but may be others, let me know or add them to the search string creation. I've tested lots of ids from moodyz, waap, mvg but others may need some tweaking.

Also, old Moodyz titles are listed by their VHS tag, for example, MDED-XXX titles are listed as MDE-XXX and so on. Got them fixed when doing an specific scrape, but id check fail will exclude them from the amalgamation process.

R18 ids can't be trusted in some cases, like HRDV-00688 and similar. The search function will get the correct movie despite having a completely different content id, but the amalgamation function will discard them for this id mismatch.

Finally, I decided to remove all additional scraping on the DMM site, the reason been that you already get all the information from the amalgamation process, or you just go with what is available on r18.com, just like when doing a specific search on other english only sites like javlibrary. I'll revert it back if you don't like this change.

Now the scrap is fast, quite accurate, and won't get banned from google search and the like.
