### PR TITLE
Fixes for network shares

### DIFF
--- a/JAVMovieScraper/src/moviescraper/doctord/controller/Renamer.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/controller/Renamer.java
@@ -109,7 +109,7 @@ public class Renamer {
 		if(newPath.startsWith(doublePathSeperator))
 		{
 			cutPath = doublePathSeperator;
-			newPath = path.substring(2,path.length());
+			newPath = newPath.substring(2,newPath.length());
 		}
 		while(newPath.contains(doublePathSeperator))
 		{

--- a/JAVMovieScraper/src/moviescraper/doctord/controller/WriteFileDataAction.java
+++ b/JAVMovieScraper/src/moviescraper/doctord/controller/WriteFileDataAction.java
@@ -84,7 +84,23 @@ public class WriteFileDataAction implements ActionListener {
 								}
 								else if(oldMovieFile.isFile())
 								{
-									FileUtils.moveFile(oldMovieFile, newMovieFile);
+									/* Faster on network shares to move to directory then rename */
+									File oldMovieDirectoryFile = oldMovieFile.getParentFile().getCanonicalFile();
+									File newMovieDirectoryFile = newMovieFile.getParentFile().getCanonicalFile();
+									File oldMovieNameFile = new File(oldMovieFile.getName());
+									File newMovieNameFile = new File(newMovieFile.getName());
+									
+									if(!newMovieDirectoryFile.equals(oldMovieDirectoryFile))
+									{
+										// Move to new directory
+										FileUtils.moveFileToDirectory(oldMovieFile, newMovieDirectoryFile, true);
+									}
+									
+									// Create paths based on new directory and rename file
+									File newDirOldNameFile = new File(newMovieDirectoryFile, oldMovieNameFile.toString());
+									File newDirNewNameFile = new File(newMovieDirectoryFile, newMovieNameFile.toString());
+									
+									FileUtils.moveFile(newDirOldNameFile, newDirNewNameFile);
 								}
 							}
 							catch(FileExistsException e)


### PR DESCRIPTION
Hi, these two commits change a few things for better operation on network shares. The change to Renamer.java fixes a bug introduced in the fix for #119. The original fix uses the original path and won't allow any changes to the folder if the path has the leading \\.

The changes to WriteFileDataAction.java should help make file renaming faster on network shares (I'm using a samba share). FileUtils.moveFile() will do a copy/delete on remote systems which for some reason gets triggered when I move files to another directory. Using FileUtils.moveFileToDirectory and then FileUtils.moveFile within the same directory performs the same rename instantly instead of having to transfer the entire file over the network.