### PR TITLE
Fix WriteFileDataAction exceptions

### DIFF
--- a/src/main/java/moviescraper/doctord/controller/WriteFileDataAction.java
+++ b/src/main/java/moviescraper/doctord/controller/WriteFileDataAction.java
@@ -64,6 +64,11 @@ public class WriteFileDataAction implements ActionListener {
 								String newMovieFilename = renamer.getNewFileName(oldMovieFile.isDirectory());
 								System.out.println("New Filename : " + newMovieFilename);
 								File newMovieFile = new File(newMovieFilename);
+
+								File newMovieDirectoryFile = newMovieFile;
+								if (!oldMovieFile.isDirectory()) {
+									newMovieDirectoryFile = newMovieFile.getParentFile().getCanonicalFile();
+								}
 								/*
 								 * old method
 								boolean renameStatus = oldMovieFile.renameTo(newMovieFile);
@@ -77,9 +82,15 @@ public class WriteFileDataAction implements ActionListener {
 									} else if (oldMovieFile.isFile()) {
 										/* Faster on network shares to move to directory then rename */
 										File oldMovieDirectoryFile = oldMovieFile.getParentFile().getCanonicalFile();
-										File newMovieDirectoryFile = newMovieFile.getParentFile().getCanonicalFile();
 										File oldMovieNameFile = new File(oldMovieFile.getName());
 										File newMovieNameFile = new File(newMovieFile.getName());
+
+										System.out.println("==============\n Moving file:");
+										System.out.println("   - oldMovieDirectoryFile: " + oldMovieDirectoryFile.getPath());
+										System.out.println("   - newMovieDirectoryFile: " + newMovieDirectoryFile.getPath());
+										System.out.println("   - oldMovieNameFile: " + oldMovieNameFile.getPath());
+										System.out.println("   - newMovieNameFile: " + newMovieNameFile.getPath());
+										System.out.println("==============");
 
 										if (!newMovieDirectoryFile.equals(oldMovieDirectoryFile)) {
 											// Move to new directory
@@ -97,11 +108,11 @@ public class WriteFileDataAction implements ActionListener {
 								}
 
 								guiMain.movieToWriteToDiskList.get(movieNumberInList).writeToFile(
-										new File(Movie.getFileNameOfNfo(newMovieFile, guiMain.getPreferences().getNfoNamedMovieDotNfo())),
-										new File(Movie.getFileNameOfPoster(newMovieFile, guiMain.getPreferences().getNoMovieNameInImageFiles())),
-										new File(Movie.getFileNameOfFanart(newMovieFile, guiMain.getPreferences().getNoMovieNameInImageFiles())),
-										new File(Movie.getFileNameOfFolderJpg(newMovieFile)), new File(Movie.getFileNameOfExtraFanartFolderName(newMovieFile)),
-										new File(Movie.getFileNameOfTrailer(newMovieFile)), guiMain.getPreferences());
+										new File(Movie.getFileNameOfNfo(newMovieDirectoryFile, guiMain.getPreferences().getNfoNamedMovieDotNfo())),
+										new File(Movie.getFileNameOfPoster(newMovieDirectoryFile, guiMain.getPreferences().getNoMovieNameInImageFiles())),
+										new File(Movie.getFileNameOfFanart(newMovieDirectoryFile, guiMain.getPreferences().getNoMovieNameInImageFiles())),
+										new File(Movie.getFileNameOfFolderJpg(newMovieDirectoryFile)), new File(Movie.getFileNameOfExtraFanartFolderName(newMovieDirectoryFile)),
+										new File(Movie.getFileNameOfTrailer(newMovieDirectoryFile)), guiMain.getPreferences());
 							} else {
 								//save without renaming movie
 								guiMain.movieToWriteToDiskList.get(movieNumberInList).writeToFile(guiMain.getCurrentlySelectedNfoFileList().get(movieNumberInList),

--- a/src/main/java/moviescraper/doctord/controller/WriteFileDataAction.java
+++ b/src/main/java/moviescraper/doctord/controller/WriteFileDataAction.java
@@ -101,7 +101,13 @@ public class WriteFileDataAction implements ActionListener {
 										File newDirOldNameFile = new File(newMovieDirectoryFile, oldMovieNameFile.toString());
 										File newDirNewNameFile = new File(newMovieDirectoryFile, newMovieNameFile.toString());
 
-										FileUtils.moveFile(newDirOldNameFile, newDirNewNameFile);
+										if(!newDirOldNameFile.equals(newDirNewNameFile)) {
+											System.out.println("-----\n Renaming movie file:");
+											System.out.println("   - newDirOldNameFile: " + newDirOldNameFile.getPath());
+											System.out.println("   - newDirNewNameFile: " + newDirNewNameFile.getPath());
+											System.out.println("==============");
+											FileUtils.moveFile(newDirOldNameFile, newDirNewNameFile);
+										}
 									}
 								} catch (FileExistsException e) {
 									System.out.println("A file or directory already exists at " + newMovieFile + " - skipping overwrite or creation of new folder.");


### PR DESCRIPTION
In latest versions always run into the following exceptions when writing data:

## 1. exception writing metadata when source is a file

we used `newMovieFile` as the destination path for the metadata files whether the movie was a file, or a directory.

If it is a directory, that is okay, the directory is renamed, then metadata is written to it.

If it is a file though, that breaks, because the content of `newMovieFile` after rename is a file path, not a directory path.

**Fix:** use `newMovieDirectoryFile` as the destination path instead, and define it in both branches, whether the source is a file or a directory.

## 2. exception on rename when file is already named correctly

we cannot rename the file to same filename, it is a no-op

**Fix:** add a check to ensure old filepath and new filepath are not identical before attempting the rename.
