### PR TITLE
Migrate to Java 12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ apply plugin: 'checkstyle'
 apply plugin: "com.diffplug.gradle.spotless"
 apply plugin: 'jacoco'
 
+compileJava.options.encoding = 'UTF-8'
+compileTestJava.options.encoding = 'UTF-8'
+
 ext.mainClass = 'moviescraper.doctord.Main'
 version = getVersionCode()
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
 	id 'application'
 	id 'org.openjfx.javafxplugin' version '0.0.7'
-	id 'com.github.johnrengelman.shadow' version '2.0.4'
+	id 'com.github.johnrengelman.shadow' version '5.0.0'
 	id "com.diffplug.gradle.spotless" version "3.13.0"
 	id "org.sonarqube" version "2.5"
 }
@@ -62,6 +62,9 @@ dependencies {
 		'com.jgoodies:forms:1.3.0',
 		'org.apache.httpcomponents:httpclient:4.5.3'
 	)
+		runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:win"
+		runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:linux"
+		runtimeOnly "org.openjfx:javafx-graphics:$javafx.version:mac"
 	testCompile('junit:junit:4.+')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 plugins {
+	id 'application'
+	id 'org.openjfx.javafxplugin' version '0.0.7'
 	id 'com.github.johnrengelman.shadow' version '2.0.4'
 	id "com.diffplug.gradle.spotless" version "3.13.0"
 	id "org.sonarqube" version "2.5"
@@ -10,6 +12,7 @@ apply plugin: 'checkstyle'
 apply plugin: "com.diffplug.gradle.spotless"
 apply plugin: 'jacoco'
 
+sourceCompatibility = '12.0'
 compileJava.options.encoding = 'UTF-8'
 compileTestJava.options.encoding = 'UTF-8'
 
@@ -19,6 +22,14 @@ version = getVersionCode()
 repositories {
 	mavenCentral()
 	maven { url "http://clojars.org/repo/" }
+}
+
+application {
+	mainClassName = 'moviescraper.doctord.Main'
+}
+
+javafx {
+	modules = [ 'javafx.swing' ]
 }
 
 sourceSets {
@@ -55,7 +66,6 @@ dependencies {
 }
 
 jar {
-
 	into 'resources', {
 		from 'resources'
 	}
@@ -68,8 +78,6 @@ jar {
 		)
 	}
 }
-
-
 
 shadowJar {
 	baseName = project.name
@@ -90,3 +98,5 @@ jacocoTestReport {
 check.dependsOn jacocoTestReport
 
 apply from: "gradle/codacy_coverage.gradle"
+
+// vim: set nolist noexpandtab softtabstop=8 shiftwidth=8:


### PR DESCRIPTION
I know it is a huge change, I originally did this for myself to resolve the annoying issue on HiDPI mode of Windows 10. But since migrate to Java 12 also give us extra benefits:

- Support HiDPI mode on Windows 10. It is really annoying to workaround this with Java 8.
- (Perhaps) make the project easier to contribute. May it's wrong since I'm not a native Java user, but new features of tools should always be attractive.

So I would like to submit this PR to open a discussion with you guys.

Note: Although `gradle run` works on Windows, but `gradle shadowJar` and `gradle jar` still doesn't work as the original master branch does. It looks like caused by a strange issue in Gradle itself, so we still need a Linux/macOS/WSL to create jar.