### PR TITLE
Silence NullPointerException on cookie jar creation

### DIFF
--- a/src/main/java/moviescraper/doctord/scraper/DitzyHeadlessBrowser.java
+++ b/src/main/java/moviescraper/doctord/scraper/DitzyHeadlessBrowser.java
@@ -32,7 +32,11 @@ public class DitzyHeadlessBrowser {
 	public void configure() throws IOException {
 		MoviescraperPreferences preferences = MoviescraperPreferences.getInstance();
 		setUserAgent(preferences.getUserAgent());
-		Cookies().LoadCookieJar(new File(preferences.getCookieJar()));
+		try {
+			Cookies().LoadCookieJar(new File(preferences.getCookieJar()));
+		} catch (NullPointerException e) {
+
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Compiling on Arch Linux with Java13 yields a NullPointerException on the file used to create the cookie jar.

For now, this simply try…catch the NullPointerException and does nothing, effectively silencing it.