### PR TITLE
Code fixes

### DIFF
--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
@@ -766,5 +766,32 @@ public class DmmParsingProfile extends SiteParsingProfile implements SpecificPro
 	public String getParserName() {
 		return "DMM.co.jp";
 	}
+	
+	// Check for age check on DMM.co.jp
+        @Override
+	public boolean requiresSecurityPassthrough(Document document) {
+		if (document != null && document.html().contains("ageCheck")) {
+			System.out.println("Found age check on DMM.co.jp; attempting to bypass");
+			return true;
+		}
+		return false;
+	}
+
+	// Handle age check on DMM.co.jp
+	@Override
+	public Document runSecurityPassthrough(Document document, SearchResult originalSearchResult) {
+		//find the last link in the document, download the href, then try to download the original result again
+		if (document != null) {
+			Element lastLink = document.select("a").last();
+			if (lastLink != null && lastLink.attr("href") != null) {
+				Document ageCheckSolved = SiteParsingProfile.getDocument(new SearchResult(lastLink.attr("href")));
+				if (ageCheckSolved != null) {
+					//return SiteParsingProfile.getDocument(originalSearchResult);
+					return ageCheckSolved;
+				}
+			}
+		}
+		return document;
+	}
 
 }

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
@@ -15,6 +15,7 @@ import java.util.regex.Pattern;
 
 import moviescraper.doctord.controller.languagetranslation.Language;
 import moviescraper.doctord.controller.languagetranslation.TranslateString;
+import moviescraper.doctord.controller.siteparsingprofile.SecurityPassthrough;
 import moviescraper.doctord.controller.siteparsingprofile.SiteParsingProfile;
 import moviescraper.doctord.model.SearchResult;
 import moviescraper.doctord.model.dataitem.Actor;

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
@@ -786,7 +786,6 @@ public class DmmParsingProfile extends SiteParsingProfile implements SpecificPro
 			if (lastLink != null && lastLink.attr("href") != null) {
 				Document ageCheckSolved = SiteParsingProfile.getDocument(new SearchResult(lastLink.attr("href")));
 				if (ageCheckSolved != null) {
-					//return SiteParsingProfile.getDocument(originalSearchResult);
 					return ageCheckSolved;
 				}
 			}

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
@@ -48,7 +48,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-public class DmmParsingProfile extends SiteParsingProfile implements SpecificProfile {
+public class DmmParsingProfile extends SiteParsingProfile implements SpecificProfile, SecurityPassthrough {
 
 	final static double dmmMaxRating = 5.00;
 	private boolean doGoogleTranslation;

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
@@ -65,7 +65,9 @@ public class DmmParsingProfile extends SiteParsingProfile implements SpecificPro
 	public DmmParsingProfile() {
 		super();
 		doGoogleTranslation = (scrapingLanguage == Language.ENGLISH);
-		scrapeTrailers = true;
+
+		// we can skip trailer scraping if user disables write trailer preference
+		scrapeTrailers = MoviescraperPreferences.getInstance().getWriteTrailerToFile();
 	}
 
 	public DmmParsingProfile(Document document) {
@@ -84,7 +86,9 @@ public class DmmParsingProfile extends SiteParsingProfile implements SpecificPro
 		this.doGoogleTranslation = doGoogleTranslation;
 		if (this.doGoogleTranslation == false)
 			setScrapingLanguage(Language.JAPANESE);
-		scrapeTrailers = true;
+
+		// we can skip trailer scraping if user disables write trailer preference
+		scrapeTrailers = MoviescraperPreferences.getInstance().getWriteTrailerToFile();
 	}
 
 	public DmmParsingProfile(boolean doGoogleTranslation, boolean scrapeTrailers) {

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/DmmParsingProfile.java
@@ -768,7 +768,7 @@ public class DmmParsingProfile extends SiteParsingProfile implements SpecificPro
 	}
 	
 	// Check for age check on DMM.co.jp
-        @Override
+	@Override
 	public boolean requiresSecurityPassthrough(Document document) {
 		if (document != null && document.html().contains("ageCheck")) {
 			System.out.println("Found age check on DMM.co.jp; attempting to bypass");

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/JavZooParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/JavZooParsingProfile.java
@@ -320,7 +320,8 @@ public class JavZooParsingProfile extends SiteParsingProfile implements Specific
 		URLCodec codec = new URLCodec();
 		try {
 			String fileNameURLEncoded = codec.encode(fileNameNoExtension);
-			String searchTerm = "http://www.javdog.com/" + siteLanguageToScrape + "/search/" + fileNameURLEncoded;
+//			String searchTerm = "http://www.javdog.com/" + siteLanguageToScrape + "/search/" + fileNameURLEncoded;
+			String searchTerm = "http://avmoo.host/" + siteLanguageToScrape + "/search/" + fileNameURLEncoded;
 
 			return searchTerm;
 

--- a/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/R18ParsingProfile.java
+++ b/src/main/java/moviescraper/doctord/controller/siteparsingprofile/specific/R18ParsingProfile.java
@@ -94,7 +94,7 @@ public class R18ParsingProfile extends SiteParsingProfile implements SpecificPro
 				System.out.println("Visiting set page to get full text");
 				try {
 					Document setDocument = SiteParsingProfile.downloadDocumentFromURLString(setElement.attr("href"));
-					Element setElementFullText = setDocument.select("div.cmn-ttl-tabMain01 div.txt01").first();
+					Element setElementFullText = setDocument.select("div.cmn-ttl-tabMain01 h1.txt01").first();
 					if (setElementFullText != null) {
 						return new Set(setElementFullText.text());
 					}

--- a/src/main/java/moviescraper/doctord/model/dataitem/MovieDataItem.java
+++ b/src/main/java/moviescraper/doctord/model/dataitem/MovieDataItem.java
@@ -39,7 +39,7 @@ public abstract class MovieDataItem implements Serializable {
 
 	public boolean isStringValueEmpty() {
 		String toStringValue = this.toString();
-		if (toStringValue.contains("=\"\""))
+		if (toStringValue.contains("=\"\" "))
 			return false;
 		else
 			return true;


### PR DESCRIPTION
- Fix for #325 - Adding logic to handle age check on DMM.co.jp
- Fix for #298 - Skip trailer scraping for DMM if user disables "write trailer" preference
- Fix for #322 - Titles that start with " (double quotes) is considered empty. This is bug is fixed.
- Fix for #273 - Update javzoo scaper to URL: avmoo.host
- Fix Movie Set scraping on R18.